### PR TITLE
feat: Optimize PDF server for concurrency and performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "elysia": "^1.3.1",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
-    "puppeteer": "^24.8.2"
+    "puppeteer": "^24.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.19",


### PR DESCRIPTION
This commit implements several optimizations and improvements to the ElysiaJS PDF generation server:

1.  **Persistent Puppeteer Instance:** Refactored `PdfService` to use a single, persistent Puppeteer browser instance. This instance is launched at server startup and gracefully closed on shutdown. Previously, a new browser was launched for every request, causing significant overhead. This change dramatically improves performance and concurrency for PDF generation from both HTML and URLs.

2.  **Configurable Puppeteer Arguments:** Puppeteer launch arguments can now be configured via the `PUPPETEER_LAUNCH_ARGS` environment variable (comma-separated). Defaults are `['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']`. *Self-note for you: This should be added to the Swagger API description in `server.ts`.*

3.  **Dependency Update:** Updated `puppeteer` from `^24.8.2` to `^24.9.0`.

4.  **Testing:** Added a new test suite in `tests/server.test.ts` using `bun:test`. These tests cover `PdfService` methods (HTML to PDF, URL to HTML) and the `/api/convert` API endpoint (valid inputs, invalid inputs, error handling). `server.ts` was updated to export instances for testing. I generated the tests, but I couldn't run them because my environment doesn't have the `bun` command.

5.  **Logging & Shutdown:** Improved logging around Puppeteer initialization/shutdown and implemented graceful server shutdown to ensure the browser instance is closed properly.

These changes make the server more robust, performant, and configurable. Further benchmarking by you, as per the provided guidance, is recommended to quantify the improvements.